### PR TITLE
feat(info): add `info` command to show CLI assets - release notes, homepage, etc 🥷

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { AssetsCommand } from '@commands/assets/assets.command'
 import { ExternalCommand } from '@commands/external/external.command'
+import { InfoCommand } from '@commands/info/info.command'
 import { InitScriptCommand } from '@commands/init-script/init-script.command'
 import { InitCommand } from '@commands/init/init.command'
 import { InstallCommand } from '@commands/install/install.command'
@@ -18,6 +19,7 @@ const COMMANDS = [
     ShellCommand,
     UpdateCommand,
     AssetsCommand,
+    InfoCommand,
     ...ExternalCommand.registerWithSubCommands(),
 ]
 

--- a/src/commands/info/config/cli-assets.config.ts
+++ b/src/commands/info/config/cli-assets.config.ts
@@ -1,0 +1,3 @@
+export const HOMEPAGE_URL = `https://avivbens.github.io/shell-config/`
+
+export const RELEASE_NOTES_URL = `https://github.com/Avivbens/shell-config/blob/master/CHANGELOG.md`

--- a/src/commands/info/info.command.ts
+++ b/src/commands/info/info.command.ts
@@ -1,0 +1,66 @@
+import { Command, CommandRunner, Option } from 'nest-commander'
+import { exit } from 'node:process'
+import { InstallCommand } from '@commands/install/install.command'
+import { execPromise } from '@common/utils'
+import { LoggerService } from '@nestjs/common'
+import { InjectLogger } from '@services/logger'
+import { HOMEPAGE_URL, RELEASE_NOTES_URL } from './config/cli-assets.config'
+import { IInfoCommandOptions } from './models/info.options'
+
+@Command({
+    name: 'info',
+    description: 'View the shell-config CLI assets - release notes, homepage, etc 🚀',
+    options: { isDefault: false },
+})
+export class InfoCommand extends CommandRunner {
+    constructor(@InjectLogger(InstallCommand.name) private readonly logger: LoggerService) {
+        super()
+    }
+
+    @Option({
+        name: 'homepage',
+        flags: '--homepage',
+        defaultValue: false,
+        description: 'Open the homepage of the shell-config CLI',
+    })
+    private homepage(): boolean {
+        return true
+    }
+
+    @Option({
+        name: 'releaseNotes',
+        flags: '--release-notes, -r',
+        defaultValue: true,
+        description: 'Open the release notes of the shell-config CLI',
+    })
+    private releaseNote(): boolean {
+        return true
+    }
+
+    private async openAsset(asset: string): Promise<void> {
+        try {
+            const command = `open "${asset}"`
+            await execPromise(command)
+        } catch (error) {
+            this.logger.debug(`Error openAsset | error: ${error.stack}`)
+            throw error
+        }
+    }
+
+    async run(inputs: string[], options: IInfoCommandOptions): Promise<void> {
+        try {
+            const { homepage, releaseNotes } = options
+            if (homepage) {
+                return this.openAsset(HOMEPAGE_URL)
+            }
+
+            if (releaseNotes) {
+                return this.openAsset(RELEASE_NOTES_URL)
+            }
+        } catch (error) {
+            this.logger.debug(`Error InstallCommand, error: ${error.stack}`)
+            this.logger.error(`Unknown error - please try again.`)
+            exit(1)
+        }
+    }
+}

--- a/src/commands/info/models/info.options.ts
+++ b/src/commands/info/models/info.options.ts
@@ -1,0 +1,15 @@
+export interface IInfoCommandOptions {
+    /**
+     * Open the homepage of the shell-config CLI
+     *
+     * @default false
+     */
+    homepage: boolean
+
+    /**
+     * Open the release notes of the shell-config CLI
+     *
+     * @default true
+     */
+    releaseNotes: boolean
+}

--- a/src/services/check-update.service.ts
+++ b/src/services/check-update.service.ts
@@ -38,7 +38,7 @@ export class CheckUpdateService {
                 return false
             }
 
-            const message = `Update available ${currentVersionClean} → ${latestClean}\nRun 'shell-config update' to update`
+            const message = `Update available ${currentVersionClean} → ${latestClean}\nRun 'shell-config update' to update\n\nRun 'shell-config info' to view the release notes 🚀`
             console.log(
                 boxen(message, {
                     padding: 1,


### PR DESCRIPTION
## Demo

![CleanShot 2025-05-13 at 20 44 20@2x](https://github.com/user-attachments/assets/3659721c-988c-4bbd-8bb1-f527e2403c32)

